### PR TITLE
Fix bug to allow Mono.ZeroConf to work on Windows with Bonjour

### DIFF
--- a/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/Service.cs
+++ b/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/Service.cs
@@ -133,8 +133,8 @@ namespace Mono.Zeroconf.Providers.Bonjour
         }
 
         public ushort UPort {
-            get { return (ushort)IPAddress.NetworkToHostOrder((int)port); }
-            set { port = (ushort)IPAddress.HostToNetworkOrder((int)value); }
+            get { return port;}
+            set { port = value;}
         }
     }
 }


### PR DESCRIPTION
Hi all,

In the Bonjour Provider, the port was always set to 0

This is a little fix. Patch has been successfully tested on Windows and Linux.

Thanks
