### PR TITLE
DNSServiceRegister port argument is supposed to be in network byte order.

### DIFF
--- a/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/RegisterService.cs
+++ b/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/RegisterService.cs
@@ -106,7 +106,7 @@ namespace Mono.Zeroconf.Providers.Bonjour
             
             ServiceError error = Native.DNSServiceRegister(out sd_ref, 
                 auto_rename ? ServiceFlags.None : ServiceFlags.NoAutoRename, InterfaceIndex,
-                Name, RegType, ReplyDomain, HostTarget, port, txt_rec_length, txt_rec,
+                Name, RegType, ReplyDomain, HostTarget, (ushort)System.Net.IPAddress.HostToNetworkOrder((short)port), txt_rec_length, txt_rec,
                 register_reply_handler, IntPtr.Zero);
 
             if(error != ServiceError.NoError) {

--- a/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/Service.cs
+++ b/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/Service.cs
@@ -132,9 +132,9 @@ namespace Mono.Zeroconf.Providers.Bonjour
             set { UPort = (ushort)value; }
         }
 
-        public ushort UPort {
-            get { return (ushort)IPAddress.NetworkToHostOrder((int)port); }
-            set { port = (ushort)IPAddress.HostToNetworkOrder((int)value); }
-        }
+		public ushort UPort {
+			get { return port; }
+			set { port = value; }
+		}
     }
 }


### PR DESCRIPTION
DNSServiceRegister port argument is supposed to be in network byte order. It was being sent in host byte order. I confirmed using avahi-browse -avtlr on a different network node.
