### PR TITLE
Fixed a couple crashes

### DIFF
--- a/src/Mono.Zeroconf.Providers.AvahiDBus/Mono.Zeroconf.Providers.AvahiDBus/RegisterService.cs
+++ b/src/Mono.Zeroconf.Providers.AvahiDBus/Mono.Zeroconf.Providers.AvahiDBus/RegisterService.cs
@@ -38,6 +38,9 @@ namespace Mono.Zeroconf.Providers.AvahiDBus
         private IAvahiEntryGroup entry_group;
         
         public event RegisterServiceEventHandler Response;
+
+		private string originalName;
+		private int retryNameModifier = 2;
      
         public RegisterService ()
         {
@@ -95,12 +98,22 @@ namespace Mono.Zeroconf.Providers.AvahiDBus
             switch (state) {
                 case EntryGroupState.Collision:
                     if (!OnResponse (ErrorCode.Collision)) {
-                        throw new ApplicationException ();
+						if (originalName == null)
+							originalName = Name;
+						
+						Name = originalName + " (" + retryNameModifier + ")";
+						retryNameModifier++;
+						
+						Console.WriteLine("ZeroConf had a name collision, trying: " + Name);
+						
+						Register();
+                        //throw new ApplicationException ();
                     }
                     break;
                 case EntryGroupState.Failure:
                     if (!OnResponse (ErrorCode.Failure)) {
-                        throw new ApplicationException ();
+						Console.WriteLine("Mono.ZeroConf failed to register name with AvahiDBus");
+                        //throw new ApplicationException ();
                     }
                     break;
                 case EntryGroupState.Established:

--- a/src/Mono.Zeroconf/Mono.Zeroconf.Providers/ProviderFactory.cs
+++ b/src/Mono.Zeroconf/Mono.Zeroconf.Providers/ProviderFactory.cs
@@ -91,23 +91,27 @@ namespace Mono.Zeroconf.Providers
             }
             
             foreach(string directory in directories) {
-                foreach(string file in Directory.GetFiles(directory, "Mono.Zeroconf.Providers.*.dll")) {
-                    if(Path.GetFileName(file) != Path.GetFileName(this_asm_path)) {
-                        Assembly provider_asm = Assembly.LoadFile(file);
-                        foreach(Attribute attr in provider_asm.GetCustomAttributes(false)) {
-                            if(attr is ZeroconfProviderAttribute) {
-                                Type type = (attr as ZeroconfProviderAttribute).ProviderType;
-                                IZeroconfProvider provider = (IZeroconfProvider)Activator.CreateInstance(type);
-                                try {
-                                    provider.Initialize();
-                                    providers_list.Add(provider);
-                                } catch (Exception e) {
-                                    Console.WriteLine (e);
-                                }
-                            }
-                        }
-                    }
-                }
+				try
+				{
+					foreach(string file in Directory.GetFiles(directory, "Mono.Zeroconf.Providers.*.dll")) {
+						if(Path.GetFileName(file) != Path.GetFileName(this_asm_path)) {
+							Assembly provider_asm = Assembly.LoadFile(file);
+							foreach(Attribute attr in provider_asm.GetCustomAttributes(false)) {
+								if(attr is ZeroconfProviderAttribute) {
+									Type type = (attr as ZeroconfProviderAttribute).ProviderType;
+									IZeroconfProvider provider = (IZeroconfProvider)Activator.CreateInstance(type);
+									try {
+										provider.Initialize();
+										providers_list.Add(provider);
+									} catch (Exception e) {
+										Console.WriteLine (e);
+									}
+								}
+							}
+						}
+					}
+				}
+				catch {}
             }
             
             if(providers_list.Count == 0) {


### PR DESCRIPTION
I ran into some issues when integrating ZeroConf into my project:
- Fixed crash in ZeroConf.dll when embedded using mkbundle
- Fixed crash in Avahi provider when it encounters a name collision (now tries name (2), etc like the Bonjour plugin does automatically)
