### PR TITLE
Use correct service type for DNSServiceQueryRecord

### DIFF
--- a/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/BrowseService.cs
+++ b/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/BrowseService.cs
@@ -134,7 +134,7 @@ namespace Mono.Zeroconf.Providers.Bonjour
             
             if (AddressProtocol == AddressProtocol.Any || AddressProtocol == AddressProtocol.IPv6) {
                 ServiceError error = Native.DNSServiceQueryRecord(out sd_ref, ServiceFlags.None, interfaceIndex,
-                    hosttarget, ServiceType.A6, ServiceClass.IN, query_record_reply_handler, IntPtr.Zero);
+                    hosttarget, ServiceType.AAAA, ServiceClass.IN, query_record_reply_handler, IntPtr.Zero);
                 
                 if(error != ServiceError.NoError) {
                     throw new ServiceErrorException(error);

--- a/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/ServiceType.cs
+++ b/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/ServiceType.cs
@@ -56,7 +56,7 @@ namespace Mono.Zeroconf.Providers.Bonjour
         KEY       = 25,     /* Security key. */
         PX        = 26,     /* X.400 mail mapping. */
         GPOS      = 27,     /* Geographical position (withdrawn). */
-        AAAA      = 28,     /* Ip6 Address. */
+        AAAA      = 28,     /* IPv6 Address. */
         LOC       = 29,     /* Location Information. */
         NXT       = 30,     /* Next domain (security). */
         EID       = 31,     /* Endpoint identifier. */
@@ -66,7 +66,7 @@ namespace Mono.Zeroconf.Providers.Bonjour
         NAPTR     = 35,     /* Naming Authority PoinTeR */
         KX        = 36,     /* Key Exchange */
         CERT      = 37,     /* Certification record */
-        A6        = 38,     /* IPv6 address (deprecates AAAA) */
+        A6        = 38,     /* IPv6 Address (deprecated) */
         DNAME     = 39,     /* Non-terminal DNAME (for IPv6) */
         SINK      = 40,     /* Kitchen sink (experimentatl) */
         OPT       = 41,     /* EDNS0 option (meta-RR) */


### PR DESCRIPTION
Use of ServiceType.A6 (which deprecated) makes following
Native.DNSServiceProcessResult call block.

https://developer.apple.com/library/mac/documentation/Networking/Reference/DNSServiceDiscovery_CRef/Reference/reference.html#//apple_ref/doc/uid/TP40002994-CHdnssdhConstants-SW14
