### PR TITLE
Fixed unreliable browse resolve

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly:AssemblyVersion("4.0.0.90")]
+[assembly:AssemblyVersion("4.0.1.90")]
 [assembly:AssemblyTitle("Mono.Zeroconf")]
 [assembly:AssemblyDescription("Cross Platform Zeroconf for .NET")]
 [assembly:AssemblyCopyright("Copyright (C) 2006-2009 Novell, Inc.")]

--- a/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/BrowseService.cs
+++ b/src/Mono.Zeroconf.Providers.Bonjour/Mono.Zeroconf.Providers.Bonjour/BrowseService.cs
@@ -58,11 +58,17 @@ namespace Mono.Zeroconf.Providers.Bonjour
         {
             resolve_reply_handler = new Native.DNSServiceResolveReply(OnResolveReply);
             query_record_reply_handler = new Native.DNSServiceQueryRecordReply(OnQueryRecordReply);
+            resolveAction = new Action<bool>(Resolve);
         }
 
+        private Action<bool> resolveAction;
         public void Resolve()
         {
-            Resolve(false);
+            // If people call this in a ServiceAdded eventhandler (which they genreally do)
+            // We need to invoke onto another thread otherwise we block processing any more results.
+
+            resolveAction.BeginInvoke(false, null, null);
+
         }
         
         public void Resolve(bool requery)


### PR DESCRIPTION
I found that with more than about 4 devices to discover on the network doing a Browse, Resolve in sequence would often only find about three of them. This was because the Resolve was blocking the Browse from completing so I made it async.